### PR TITLE
Key is optional in producing records

### DIFF
--- a/lib/kashka/kafka.ex
+++ b/lib/kashka/kafka.ex
@@ -23,13 +23,13 @@ defmodule Kashka.Kafka do
         }
 
   @type json_records :: %{
-          required(:key) => String.t(),
+          optional(:key) => String.t(),
           required(:value) => any(),
           optional(:partition) => integer()
         }
 
   @type binary_records :: %{
-          required(:key) => String.t(),
+          optional(:key) => String.t(),
           required(:value) => String.t(),
           optional(:partition) => integer()
         }
@@ -309,7 +309,7 @@ defmodule Kashka.Kafka do
   end
 
   @doc """
-  Build connection to exsisting consumer. 
+  Build connection to exsisting consumer.
   This function mostly used in tests when there is only one kafka rest proxy instance
 
   ## Parameters

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Kashka.MixProject do
   def project do
     [
       app: :kashka,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/funbox/kashka",


### PR DESCRIPTION
```
records[i].key (object) – The message key, formatted according to the embedded format, or null to omit a key (optional)
```
https://docs.confluent.io/platform/current/kafka-rest/api.html#post--topics-(string-topic_name)